### PR TITLE
Fix export function to print whole list

### DIFF
--- a/source/exportBtn/main.css
+++ b/source/exportBtn/main.css
@@ -9,3 +9,16 @@ export-button {
     top: 10px;
     right: 10px;
 }
+
+@media print {
+    main {visibility: hidden;}
+    #export {
+        position: absolute;
+        top: 2%;
+    }
+    img {
+        max-width: 200px;
+        max-height: 150px;
+        align-self: left;
+    }
+ }

--- a/source/exportBtn/main.js
+++ b/source/exportBtn/main.js
@@ -18,28 +18,19 @@ function init() {
  * Exports the current list of elements in the order shown on screen
  * Invokes a window to save as pdf, to save the current list
  */
-export function exportToPDF() {
-/////////////////////////////////////////////////////////////////////////   
-/////////////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////////// 
-	let css = "@page { size: 790px 940px; margin: 10px;}"
-	let head = document.head || document.getElementsByTagName("head")[0]
-	let style = document.createElement("style")
-
-	style.type = "text/css"
-	style.media = "print"
-	if (style.styleSheet){
-		style.styleSheet.cssText = css
-	} else {
-		style.appendChild(document.createTextNode(css))
-	}
-	head.appendChild(style)
-
-	document.getElementById("right").style.display = "none"
+export function exportToPDF(entries) {
+  let list = document.getElementById("export")
+  list.innerHTML += `<h1> WHERE2EAT </h1>`
+  for (let i = 0; i < entries.length; i++) {
+    list.innerHTML += `<h3> ${i + 1}. ${entries[i].name}</h3>
+                      <img src= "${entries[i].img}">
+                      <p> Rating: ${entries[i].rating}; Price: ${entries[i].price}; Tags: ${entries[i].tags}; Description: ${entries[i].description} </p>
+                      <br>`
+  }
 
 	window.print()
 	setTimeout(() => {
-		document.getElementById("right").style.display = "block"
+    list.innerHTML = ''
 	}, 0.0000000001)
 }
 
@@ -47,10 +38,10 @@ export function exportToPDF() {
  * Add an event listener to the export button so when it is clicked, 
  * it calls exportToPDF();
  */
-export function initExportBtnHandler() {
+export function initExportBtnHandler(entries) {
 	let button = document.createElement("export-button")
 	document.body.appendChild(button)
 	button.addEventListener("click", (event) =>{
-		exportToPDF()
+		exportToPDF(entries)
 	})
 }

--- a/source/index.html
+++ b/source/index.html
@@ -66,6 +66,7 @@
     </div>
     <div id="output"></div>
   </main>
+  <div id="export"></div>
 
   <div class="footer">Questions? where2eatsupport@gmail.com</div>
 

--- a/source/list/list.js
+++ b/source/list/list.js
@@ -2,6 +2,7 @@
 
 import {getEntriesFromStorage} from "../restaurantEntry/restaurantEntryRepo.js"
 import {editPostHandler, deletePostHandler} from "../restaurantEntry/main.js"
+import {initExportBtnHandler} from "../exportBtn/main.js"
 
 window.addEventListener("DOMContentLoaded", init)
 
@@ -35,6 +36,7 @@ export function addEntriesToDocument(entries) {
 			list.appendChild(restaurantEntry)
 		}
 	}
+	initExportBtnHandler(entries)
 	editPostHandler()
 	deletePostHandler()
 }


### PR DESCRIPTION
Previously, export button only prints the entries that appear in the current state of the window. This fix allows the export button to print all entries currently appearing on the list.